### PR TITLE
Adding sample usages of the Fivetran  REST API

### DIFF
--- a/fivetran_api/Fivetran-REST-API-examples/README.md
+++ b/fivetran_api/Fivetran-REST-API-examples/README.md
@@ -1,0 +1,54 @@
+# Fivetran REST API Examples
+
+In addition to managing your Fivetran account using the dashboard, you can now perform key management actions such as creating and managing new users and creating and managing connectors using the Fivetran REST API.
+
+To get you started, we've provided several example python scripts to cover common API use cases.
+
+## Config
+
+1. Use the [Getting Started guide](https://fivetran.com/docs/rest-api/getting-started) to retrieve your API Key and API Secret.
+2. In `config.py`, replace the `API_KEY` and `API_SECRET` values with your API Key and API Secret.
+
+## Usage
+
+Call the desired python script from your external code or terminal, making sure to add your `group_id` or `connector_id` to the script where appropriate.
+
+Example: `python createConnector.py`
+
+## Included Examples
+
+### connectorDetails
+
+Returns a connector object if a valid identifier was provided.
+
+Reference: https://fivetran.com/docs/rest-api/connectors#retrieveconnectordetails
+
+### createConnector
+
+Creates a new connector within a specified group in your Fivetran account. Runs setup tests and returns testing results.
+
+Reference: https://fivetran.com/docs/rest-api/connectors#createaconnector
+
+### createFTPConnector
+
+Identical to createConnector, with the addition of advanced field configuration available to file connectors.
+
+Reference: https://fivetran.com/docs/rest-api/connectors/config#ftp
+
+### listGroupConnectors
+
+Returns a list of information about all connectors within a group in your Fivetran account.
+
+Reference: https://fivetran.com/docs/rest-api/groups#listallconnectorswithinagroup
+
+### listGroups
+
+List all Fivetran groups available to the authenticated Fivetran User.
+
+Reference: https://fivetran.com/docs/rest-api/groups
+
+### listUsers
+
+Returns a list of all users within your Fivetran account.
+
+Reference: https://fivetran.com/docs/rest-api/users#listallusers

--- a/fivetran_api/Fivetran-REST-API-examples/config.py
+++ b/fivetran_api/Fivetran-REST-API-examples/config.py
@@ -1,0 +1,3 @@
+# See https://fivetran.com/account/settings
+API_KEY = ""
+API_SECRET = ""

--- a/fivetran_api/Fivetran-REST-API-examples/connectorDetails.py
+++ b/fivetran_api/Fivetran-REST-API-examples/connectorDetails.py
@@ -1,0 +1,11 @@
+# connectorDetails
+# Returns a connector object if a valid identifier was provided.
+
+# Reference: https://fivetran.com/docs/rest-api/connectors#retrieveconnectordetails
+
+import fivetran_api
+
+# Fivetran API URL (Replace {connector_id} with a valid connector id).
+url = "https://api.fivetran.com/v1/connectors/{connector_id}"
+
+fivetran_api.dump(fivetran_api.get_url(url))

--- a/fivetran_api/Fivetran-REST-API-examples/createConnector.py
+++ b/fivetran_api/Fivetran-REST-API-examples/createConnector.py
@@ -1,0 +1,23 @@
+# createConnector
+# Creates a new connector within a specified group in your Fivetran account. Runs setup tests and returns testing results.
+
+# Reference: https://fivetran.com/docs/rest-api/connectors#createaconnector
+
+import fivetran_api
+
+# Fivetran API URL 
+url = "https://api.fivetran.com/v1/connectors/"
+#Connector Configuration (replace {group_id} with your group id)
+config_values = {
+    "service": "criteo",
+    "group_id": "{group_id}",
+    "trust_certificates": "true",
+    "config": {
+        "schema": "criteo",
+        "username": "myuser",
+        "password": "mypassword",
+        "app_token": "myapptoken"
+    }
+}
+
+fivetran_api.dump(fivetran_api.post_url(url, config_values))

--- a/fivetran_api/Fivetran-REST-API-examples/createFTPConnector.py
+++ b/fivetran_api/Fivetran-REST-API-examples/createFTPConnector.py
@@ -1,0 +1,37 @@
+# createFTPConnector
+# Identical to createConnector, with the addition of advanced field configuration available to file connectors.
+
+# Reference: https://fivetran.com/docs/rest-api/connectors/config#ftp
+
+import fivetran_api
+
+# Fivetran API URL 
+url = "https://api.fivetran.com/v1/connectors/"
+#Connector Configuration (replace {group_id} with your group id)
+config_values = {
+    "service": "ftp",
+    "group_id": "{group_id}",
+    "config": {
+        "schema": "schema_name",
+        "table": "table_name",
+        "host": "ftp.company.com",
+        "port": "21",
+        "user": "user_name",
+        "password": "password",
+        "isSecure": "false",
+        "prefix": "folder_path",
+        "pattern": "file_pattern",
+        "fileType": "infer",
+        "compression": "infer",
+        "onError": "skip",
+        "appendFileOption": "upsert_file",
+        "archivePattern": "regex_pattern",
+        "nullSequence": "",
+        "delimiter": "",
+        "escapeChar": "",
+        "skipBefore": "0",
+        "skipAfter": "0"
+    }
+}
+
+fivetran_api.dump(fivetran_api.post_url(url, config_values))

--- a/fivetran_api/Fivetran-REST-API-examples/fivetran_api.py
+++ b/fivetran_api/Fivetran-REST-API-examples/fivetran_api.py
@@ -1,0 +1,19 @@
+import json
+
+import requests
+
+from config import API_KEY, API_SECRET
+
+
+def get_url(url):
+    return requests.get(url, auth=(API_KEY, API_SECRET))
+
+
+def post_url(url, values):
+    return requests.post(url, auth=(API_KEY, API_SECRET), json=values) 
+
+
+def dump(response):
+    print(json.dumps(response.json()))
+
+

--- a/fivetran_api/Fivetran-REST-API-examples/listGroupConnectors.py
+++ b/fivetran_api/Fivetran-REST-API-examples/listGroupConnectors.py
@@ -1,0 +1,11 @@
+# listGroupConnectors
+# Returns a list of information about all connectors within a group in your Fivetran account.
+
+# Reference: https://fivetran.com/docs/rest-api/groups#listallconnectorswithinagroup
+
+import fivetran_api
+
+# Fivetran API URL (replace {group_id} with your group id)
+url = "https://api.fivetran.com/v1/groups/{group_id}/connectors"
+
+fivetran_api.dump(fivetran_api.get_url(url))

--- a/fivetran_api/Fivetran-REST-API-examples/listGroups.py
+++ b/fivetran_api/Fivetran-REST-API-examples/listGroups.py
@@ -1,0 +1,10 @@
+# listGroups
+# List all Fivetran groups available to the authenticated Fivetran User.
+
+# Reference: https://fivetran.com/docs/rest-api/groups
+
+import fivetran_api
+
+url = "https://api.fivetran.com/v1/groups"
+
+fivetran_api.dump(fivetran_api.get_url(url))

--- a/fivetran_api/Fivetran-REST-API-examples/listUsers.py
+++ b/fivetran_api/Fivetran-REST-API-examples/listUsers.py
@@ -1,0 +1,11 @@
+# listUsers
+# Returns a list of all users within your Fivetran account.
+
+# Reference: https://fivetran.com/docs/rest-api/users#listallusers
+
+import fivetran_api
+
+# Fivetran API URL (users endpoint)
+url = "https://api.fivetran.com/v1/users"
+
+fivetran_api.dump(fivetran_api.get_url(url))


### PR DESCRIPTION
Adding several real-world (python) examples using the Fivetran REST API.

@Cfwang1337 said it would be a good idea for @levonkorganyan to confirm whether this should live in the functions repo, as it will likely be linked for public consumption from blog/docs.