### PR TITLE
Added the Sync Connector Script and instructions

### DIFF
--- a/fivetran_api/Fivetran-REST-API-examples/README.md
+++ b/fivetran_api/Fivetran-REST-API-examples/README.md
@@ -60,7 +60,7 @@ Triggers a connector sync. Can be used to setup custom sync frequencies.
 Reference: https://fivetran.com/docs/rest-api/connectors#syncconnectordata
 
 #### Usage: 
-This example assumes a Linux environment and python3. It can be adjusted accordingly.
+This example assumes a Linux environment and python3. It can be adjusted accordingly. The following should be added to a given users `crontab` with `crontab -e`.
 
 ```sh
 0 0,4,8,12,16,20 * * * /usr/bin/python3 /path/to/syncConnector.py --api_key <key> --api_secret <secret> --connector_id <id> >> ~/cron.log 2>&1

--- a/fivetran_api/Fivetran-REST-API-examples/README.md
+++ b/fivetran_api/Fivetran-REST-API-examples/README.md
@@ -52,3 +52,20 @@ Reference: https://fivetran.com/docs/rest-api/groups
 Returns a list of all users within your Fivetran account.
 
 Reference: https://fivetran.com/docs/rest-api/users#listallusers
+
+### syncConnector
+
+Triggers a connector sync. Can be used to setup custom sync frequencies.
+
+Reference: https://fivetran.com/docs/rest-api/connectors#syncconnectordata
+
+#### Usage: 
+This example assumes a Linux environment and python3. It can be adjusted accordingly.
+
+```sh
+0 0,4,8,12,16,20 * * * /usr/bin/python3 /path/to/syncConnector.py --api_key <key> --api_secret <secret> --connector_id <id> >> ~/cron.log 2>&1
+```
+
+This will sync a given connector (based on connector id from the UI) at the hours of 0, 4, 8, 12, 16, and 20. You can use https://crontab.guru for help with cron syntax for other custom schedules.
+
+It uses python3 located in the `/usr/bin` folder. You then specify the path to the `syncConnector.py` file, and provide the required arguments. It will log results to the `~/cron.log` location. The `2>&1` is a redirect for `stdout` and `stderr` to the log file, so any errors and success are tracked as the script executes.

--- a/fivetran_api/Fivetran-REST-API-examples/syncConnector.py
+++ b/fivetran_api/Fivetran-REST-API-examples/syncConnector.py
@@ -1,0 +1,65 @@
+import json
+import requests
+import argparse
+
+class Connector:
+  def __init__(self, apiKey, apiSecret, version=None):
+    self._api_version = self._set_api_version(version)
+    self._api_endpoint = 'https://api.fivetran.com/{version}/connectors'.format(
+      version=self._api_version
+    )
+
+    self._auth = requests.auth.HTTPBasicAuth(apiKey, apiSecret)
+
+  def _set_api_version(self, version):
+    if version is None:
+      version = 'v1'
+    return version
+
+  def getApiEndpoint(self):
+    return self._api_endpoint
+
+  def sync(self, connectorId):
+    sync_endpoint = '{endpoint}/{connectorId}/force'.format(
+      endpoint=self.getApiEndpoint(),
+      connectorId=connectorId
+    )
+    
+    r = requests.post(
+      sync_endpoint,
+      auth=self._auth
+      # json=payload
+    ).json()
+
+    print('Result:', r['code'], r['message'])
+
+    return r
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Sync a connector")
+  parser.add_argument("--api_key")
+  parser.add_argument("--api_secret")
+  parser.add_argument("--connector_id")
+
+  args = parser.parse_args()
+
+  apiKey = args.api_key
+  apiSecret = args.api_secret
+  connectorId = args.connector_id
+
+  c = Connector(
+    apiKey=apiKey,
+    apiSecret=apiSecret
+  )
+
+  c.sync(
+    connectorId
+  )
+
+if __name__ == '__main__':
+  main()
+
+  
+
+


### PR DESCRIPTION
Base script for creating custom sync schedules. The example in the README shows how this is done via cron. The script makes calls to the necessary endpoint and requires the user supply a connector id and their api keys.